### PR TITLE
Async render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .DS_Store
+coverage

--- a/lib/sepa-xml.js
+++ b/lib/sepa-xml.js
@@ -4,18 +4,37 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var BIC = require('../bics/list');
 
-function SepaXML(format) {
-  this.outputFormat = format || 'pain.001.001.03';
+Handlebars.registerHelper('formatDate', function(dto) {
+  return new Handlebars.SafeString(formatDate(dto));
+});
+
+Handlebars.registerHelper('timestamp', function() {
+  var dto = new Date();
+  return new Handlebars.SafeString(dto.toJSON().toString());
+});
+
+function bicLookup(iban) {
+  return BIC[iban.slice(4, 8)];
 }
 
-SepaXML.prototype = {
+function formatDate(dto) {
+  dto = dto || new Date();
 
-  _header: {
+  var month = (dto.getMonth() + 1).toString();
+  var day = dto.getDate().toString();
+
+  return dto.getFullYear().toString() + '-' + (month[1] ? month : '0' + month) + '-' + (day[1] ? day : '0' + day);
+}
+
+function SepaXML(format) {
+  this.outputFormat = format || 'pain.001.001.03';
+
+  this._header = {
     messageId: null,
     initiator: null
-  },
+  };
 
-  _payments: {
+  this._payments = {
     info: {
       id: null,
       method: null,
@@ -23,7 +42,10 @@ SepaXML.prototype = {
     },
 
     transactions: []
-  },
+  };
+}
+
+SepaXML.prototype = {
 
   setHeaderInfo: function(params) {
     for (var p in params) {
@@ -42,15 +64,6 @@ SepaXML.prototype = {
 
     this.verifyCurrentInfo(function (err) {
       if (err) return cb(err);
-
-      Handlebars.registerHelper('formatDate', function(dto) {
-        return new Handlebars.SafeString(_self.formatDate(dto));
-      });
-
-      Handlebars.registerHelper('timestamp', function() {
-        var dto = new Date();
-        return new Handlebars.SafeString(dto.toJSON().toString());
-      });
 
       fs.readFile(__dirname + '/../formats/' + _self.outputFormat + '.hbs', 'utf8', function (err, source) {
         if (err) return cb(err);
@@ -82,8 +95,8 @@ SepaXML.prototype = {
   },
 
   addTransaction: function(payment) {
-    if (!payment.iban || !payment.name || !payment.amount || !payment.id) return false;
-    if (!payment.bic) payment.bic = this.bicLookup(payment.iban);
+    if (!payment || !payment.iban || !payment.name || !payment.amount || !payment.id) return false;
+    if (!payment.bic) payment.bic = bicLookup(payment.iban);
 
     this._payments.transactions.push({
       endToEndId: payment.id,
@@ -92,10 +105,6 @@ SepaXML.prototype = {
       recipientName: payment.name,
       recipientIBAN: payment.iban
     });
-  },
-
-  bicLookup: function(iban) {
-    return BIC[iban.slice(4, 8)];
   },
 
   verifyCurrentInfo: function(cb) {
@@ -112,15 +121,6 @@ SepaXML.prototype = {
     if (this._payments.transactions.length === 0) errors.push('The list of transactions is empty.');
 
     cb((errors.length === 0) ? null : errors);
-  },
-
-  formatDate: function(dto) {
-    dto = dto || new Date();
-
-    var month = (dto.getMonth() + 1).toString();
-    var day = dto.getDate().toString();
-
-    return dto.getFullYear().toString() + '-' + (month[1] ? month : '0' + month) + '-' + (day[1] ? day : '0' + day);
   }
 
 };

--- a/lib/sepa-xml.js
+++ b/lib/sepa-xml.js
@@ -37,23 +37,28 @@ SepaXML.prototype = {
     }
   },
 
-  compile: function() {
-    if (!this.verifyCurrentInfo()) return false;
+  compile: function(cb) {
     var _self = this;
 
-    Handlebars.registerHelper('formatDate', function(dto) {
-      return new Handlebars.SafeString(_self.formatDate(dto));
-    });
+    this.verifyCurrentInfo(function (err) {
+      if (err) return cb(err);
 
-    Handlebars.registerHelper('timestamp', function() {
-      var dto = new Date();
-      return new Handlebars.SafeString(dto.toJSON().toString());
-    });
+      Handlebars.registerHelper('formatDate', function(dto) {
+        return new Handlebars.SafeString(_self.formatDate(dto));
+      });
 
-    var source = fs.readFileSync(__dirname + '/../formats/' + this.outputFormat + '.hbs', 'utf8');
-    var template = Handlebars.compile(source);
-    var compiled = template(this.templateData());
-    return compiled;
+      Handlebars.registerHelper('timestamp', function() {
+        var dto = new Date();
+        return new Handlebars.SafeString(dto.toJSON().toString());
+      });
+
+      fs.readFile(__dirname + '/../formats/' + _self.outputFormat + '.hbs', 'utf8', function (err, source) {
+        if (err) return cb(err);
+
+        var template = Handlebars.compile(source);
+        cb(null, template(_self.templateData()));
+      });
+    });
   },
 
   templateData: function() {
@@ -93,7 +98,7 @@ SepaXML.prototype = {
     return BIC[iban.slice(4, 8)];
   },
 
-  verifyCurrentInfo: function() {
+  verifyCurrentInfo: function(cb) {
     var errors = [];
 
     for (var p in this._header) {
@@ -106,12 +111,7 @@ SepaXML.prototype = {
 
     if (this._payments.transactions.length === 0) errors.push('The list of transactions is empty.');
 
-    if (errors.length === 0) {
-      return true;
-    } else {
-      console.error(errors.join('\n'));
-      return false;
-    }
+    cb((errors.length === 0) ? null : errors);
   },
 
   formatDate: function(dto) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple XML generator for SEPA transactions.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "istanbul cover _mocha",
     "package:update": "npm outdated --depth=0 | grep -v Package | awk '{print $1}' | xargs -I% npm install %@latest --save"
   },
   "repository": {
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
+    "istanbul": "^0.4.2",
     "mocha": "^2.2.5"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -11,9 +11,30 @@ describe('Module loads a new function', function() {
 
 describe('Works with the `pain.001.001.03` format', function() {
   var sepaxml = new SepaXML('pain.001.001.03');
+  sepaxml.setHeaderInfo({
+    messageId: 'ABC123',
+    initiator: 'SepaXML'
+  });
 
-  it('Loads the template for the format', function() {
-    expect(sepaxml.compile()).to.be.a('string');
+  sepaxml.setPaymentInfo({
+    id: 'XYZ987',
+    method: 'TRF'
+  });
+
+  sepaxml.addTransaction({
+    id: 'TRANSAC1',
+    iban: 'NL21ABNA0531621583', // fake IBAN from https://www.generateiban.com/test-iban/ thanks
+    name: 'generateiban',
+    amount: 42
+  });
+
+  it('Loads the template for the format', function(done) {
+    sepaxml.compile(function (err, out) {
+      expect(err).to.be.null;
+      expect(out).to.be.a('string');
+
+      done();
+    });
   });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,14 @@ describe('Module loads a new function', function() {
   });
 });
 
+describe('Use default format', function () {
+  var defaultsepaxml = new SepaXML();
+
+  it('should be `pain.001.001.03` format', function () {
+    expect(defaultsepaxml.outputFormat).to.be.equal('pain.001.001.03');
+  });
+});
+
 describe('Works with the `pain.001.001.03` format', function() {
   var sepaxml = new SepaXML('pain.001.001.03');
   sepaxml.setHeaderInfo({
@@ -37,4 +45,66 @@ describe('Works with the `pain.001.001.03` format', function() {
     });
   });
 
+  it('should autofill BIC', function () {
+    expect(sepaxml._payments.transactions[0].bic).to.be.eql('ABNANL2A');
+  });
+
+  it('should made transaction Control Sum', function () {
+    expect(sepaxml._header.transactionCount).to.be.equal(1);
+    expect(sepaxml._header.transactionControlSum).to.be.equal(42);
+
+    expect(sepaxml._payments.transactionCount).to.be.equal(1);
+    expect(sepaxml._payments.transactionControlSum).to.be.equal(42);
+  });
+
+  describe('Validations', function () {
+    it('should return validation', function(done) {
+      var emptySepa = new SepaXML('pain.001.001.03');
+
+      emptySepa.compile(function (err, out) {
+        expect(out).to.be.undefined;
+        expect(err).to.be.eql([
+          'You have not filled in the `messageId`.',
+          'You have not filled in the `initiator`.',
+          'You have not filled in the `id`.',
+          'You have not filled in the `method`.',
+          'The list of transactions is empty.'
+        ]);
+
+        done();
+      });
+    });
+
+    it('should validate new transaction', function () {
+      expect(sepaxml.addTransaction()).to.be.false;
+      expect(sepaxml._payments.transactions.length).to.be.equal(1);
+    });
+
+    it('should use a bad format', function (done) {
+      var badformatsepaxml = new SepaXML('pain.001.001.04');
+      badformatsepaxml.setHeaderInfo({
+        messageId: 'ABC123',
+        initiator: 'SepaXML'
+      });
+
+      badformatsepaxml.setPaymentInfo({
+        id: 'XYZ987',
+        method: 'TRF'
+      });
+
+      badformatsepaxml.addTransaction({
+        id: 'TRANSAC1',
+        iban: 'NL21ABNA0531621583', // fake IBAN from https://www.generateiban.com/test-iban/ thanks
+        name: 'generateiban',
+        amount: 42
+      });
+
+      badformatsepaxml.compile(function (err) {
+        expect(err).to.be.exist;
+        expect(err.code).to.be.equal('ENOENT');
+
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Change `compile` method for async version and use async version of fs
  _callback_ should be pass

``` JavaScript
sepaxml.compile(function (err, out) {
  // Error can be an array or null
});
```
- Fix sepaxml instance
  `_header` and `_payments` are no longer shared between instances.
- Add tests and coverages :santa: 

```
Statements   : 100% ( 60/60 )
Branches     : 89.66% ( 26/29 )
Functions    : 100% ( 13/13 )
Lines        : 100% ( 53/53 )
```
