### PR TITLE
Use Big.js to calculate transaction sum

### DIFF
--- a/lib/sepa-xml.js
+++ b/lib/sepa-xml.js
@@ -3,6 +3,7 @@
 var Handlebars = require('handlebars');
 var fs = require('fs');
 var BIC = require('../bics/list');
+var Big = require('big.js')
 
 Handlebars.registerHelper('formatDate', function(dto) {
   return new Handlebars.SafeString(formatDate(dto));
@@ -75,18 +76,18 @@ SepaXML.prototype = {
   },
 
   templateData: function() {
-    var controlSum = 0;
+    var controlSum = Big(0);
     var transactionCount = this._payments.transactions.length;
 
     for (var i = 0; i < this._payments.transactions.length; i++) {
-      controlSum += parseFloat(this._payments.transactions[i].amount);
+      controlSum = Big(this._payments.transactions[i].amount).plus(controlSum);
     }
 
     this._header.transactionCount = transactionCount;
-    this._header.transactionControlSum = controlSum;
+    this._header.transactionControlSum = controlSum.toFixed(2);
 
     this._payments.info.transactionCount = transactionCount;
-    this._payments.info.transactionControlSum = controlSum;
+    this._payments.info.transactionControlSum = controlSum.toFixed(2);
 
     return {
       _header: this._header,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/mgmco/sepa-xml#readme",
   "dependencies": {
+    "big.js": "^3.1.3",
     "handlebars": "^4.0.5"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,14 @@ describe('Works with the `pain.001.001.03` format', function() {
     id: 'TRANSAC1',
     iban: 'NL21ABNA0531621583', // fake IBAN from https://www.generateiban.com/test-iban/ thanks
     name: 'generateiban',
-    amount: 42
+    amount: .1
+  });
+  
+  sepaxml.addTransaction({
+    id: 'TRANSAC1',
+    iban: 'NL21ABNA0531621583', // fake IBAN from https://www.generateiban.com/test-iban/ thanks
+    name: 'generateiban',
+    amount: 40.2
   });
 
   it('Loads the template for the format', function(done) {
@@ -50,11 +57,11 @@ describe('Works with the `pain.001.001.03` format', function() {
   });
 
   it('should made transaction Control Sum', function () {
-    expect(sepaxml._header.transactionCount).to.be.equal(1);
-    expect(sepaxml._header.transactionControlSum).to.be.equal(42);
+    expect(sepaxml._header.transactionCount).to.be.equal(2);
+    expect(sepaxml._header.transactionControlSum).to.be.equal('40.30');
 
-    expect(sepaxml._payments.info.transactionCount).to.be.equal(1);
-    expect(sepaxml._payments.info.transactionControlSum).to.be.equal(42);
+    expect(sepaxml._payments.info.transactionCount).to.be.equal(2);
+    expect(sepaxml._payments.info.transactionControlSum).to.be.equal('40.30');
   });
 
   describe('Validations', function () {
@@ -77,7 +84,7 @@ describe('Works with the `pain.001.001.03` format', function() {
 
     it('should validate new transaction', function () {
       expect(sepaxml.addTransaction()).to.be.false;
-      expect(sepaxml._payments.transactions.length).to.be.equal(1);
+      expect(sepaxml._payments.transactions.length).to.be.equal(2);
     });
 
     it('should use a bad format', function (done) {


### PR DESCRIPTION
I've added Big.js to calculate the summation of transactions and adjusted the test a bit to trigger floating point errors. The sum is now always printed with 2 decimals. 