### PR TITLE
Update pain.008.001.02.hbs to handle empty / unfound BIC

### DIFF
--- a/formats/pain.008.001.02.hbs
+++ b/formats/pain.008.001.02.hbs
@@ -64,11 +64,16 @@
             <DtOfSgntr>{{mandateSignatureDate}}</DtOfSgntr>
             <AmdmntInd>false</AmdmntInd>
           </MndtRltdInf>
-        </DrctDbtTx>
-        {{#if bic}}
+        </DrctDbtTx>        
         <DbtrAgt>
             <FinInstnId>
+              {{#if bic}}
               <BIC>{{bic}}</BIC>
+              {{else}}
+              <Othr>
+                <Id>NOTPROVIDED</Id>
+              </Othr>
+              {{/if}}
             </FinInstnId>
         </DbtrAgt>
         {{/if}}


### PR DESCRIPTION
fix to pass certification for transactions without BIC. This kept me from uploading my file due to a validation error.